### PR TITLE
fix: the log variable is removed accidently

### DIFF
--- a/src/ngx_http_grpc_client.c
+++ b/src/ngx_http_grpc_client.c
@@ -464,8 +464,8 @@ ngx_http_grpc_cli_thread_post_event_handler(ngx_event_t *ev)
 
         res = &posted_event_ctx->res;
 
-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0, "resume finished task %uL, ctx:%p",
-                    res->task_id, posted_event_ctx);
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ev->log, 0, "resume finished task %uL, ctx:%p",
+                       res->task_id, posted_event_ctx);
 
         ctx = (ngx_http_grpc_cli_ctx_t *) res->task_id;
         ctx->res = *res;


### PR DESCRIPTION
The bug is introduced in https://github.com/api7/grpc-client-nginx-module/commit/2e5e4183891b409c20b50130c05f469b7e0ff830
Signed-off-by: spacewander <spacewanderlzx@gmail.com>