### PR TITLE
fix: don't crash Nginx worker just because the debug log is unable

### DIFF
--- a/grpc-engine/main.go
+++ b/grpc-engine/main.go
@@ -38,7 +38,8 @@ func init() {
 	// only keep the latest debug log
 	f, err := os.OpenFile("/tmp/grpc-engine-debug.log", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		panic(err)
+		log.Printf(err.Error())
+		return
 	}
 	log.Default().SetOutput(f)
 	log.Default().SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>