### PR TITLE
fix: compatibility with lua-resty-shell

### DIFF
--- a/config
+++ b/config
@@ -4,7 +4,7 @@
 if [ $USE_THREADS != YES ]; then
     cat << END
 
-$0: lua_io_nginx_module depends on the threads support, please reconfigure with "--with-threads" option.
+$0: grpc-client-nginx-module depends on the threads support, please reconfigure with "--with-threads" option.
 
 END
     exit 1
@@ -40,3 +40,6 @@ ngx_module_incs=" \
 . auto/module
 
 ngx_addon_name=$ngx_module_name
+
+# After loading Go code from .so, the signalfd doesn't work anymore
+sed -i "s/#ifndef NGX_HTTP_LUA_HAVE_SIGNALFD/#ifdef NGX_HTTP_LUA_HAVE_SIGNALFD/" $NGX_AUTO_CONFIG_H

--- a/t/nginx.t
+++ b/t/nginx.t
@@ -1,0 +1,34 @@
+use t::GRPC_CLI 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: lua-resty-shell
+--- config
+location /t {
+    content_by_lua_block {
+        local gcli = require("resty.grpc")
+        assert(gcli.load("t/testdata/rpc.proto"))
+        local shell = require("resty.shell")
+        local stdin = "hello"
+        local timeout = 1000  -- ms
+        local max_size = 4096  -- byte
+
+        local ok, stdout, stderr, reason, status =
+            shell.run([[perl -e 'warn "he\n"; print <>']], stdin, timeout, max_size)
+        if not ok then
+            ngx.say(stderr)
+            return
+        end
+
+        local conn = assert(gcli.connect("127.0.0.1:2379"))
+        local res = conn:call("etcdserverpb.KV", "Put", {key = 'k', value = 'v'})
+        local old = res.header.revision
+        local res = conn:call("etcdserverpb.KV", "Put", {key = 'k', value = 'c'})
+        ngx.say(res.header.revision - old)
+        conn:close()
+    }
+}
+--- response_body
+1


### PR DESCRIPTION
By disabling signalfd which is broken after loading Go code.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>