### PR TITLE
feat: install Lua code from source during building APISIX-Base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,4 @@ install:
 	if [ ! -f /usr/local/go/bin/go ]; then ./install-util.sh install_go; fi
 	cd ./grpc-engine && PATH="$(PATH):/usr/local/go/bin" go build -o libgrpc_engine.so -buildmode=c-shared main.go
 	$(INSTALL) -m 664 ./grpc-engine/libgrpc_engine.so $(OPENRESTY_PREFIX)/
+	$(INSTALL) -m 664 lib/resty/*.lua $(OPENRESTY_PREFIX)/lualib/resty/


### PR DESCRIPTION
So we can ensure the latest APISIX-Base matches the latest Lua code.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>