### PR TITLE
feat: release v0.3.1

### DIFF
--- a/rockspec/grpc-client-nginx-module-0.3.1-0.rockspec
+++ b/rockspec/grpc-client-nginx-module-0.3.1-0.rockspec
@@ -1,8 +1,8 @@
 package = "grpc-client-nginx-module"
-version = "0.3.0-0"
+version = "0.3.1-0"
 source = {
     url = "git://github.com/api7/grpc-client-nginx-module",
-    branch = "v0.3.0",
+    branch = "v0.3.1",
 }
 
 description = {

--- a/src/ngx_grpc_client.c
+++ b/src/ngx_grpc_client.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <dlfcn.h>
 #include <stdbool.h>
 #include <ngx_config.h>


### PR DESCRIPTION
Fix "undefined reference to `assert'" when building with old compiler
Signed-off-by: spacewander <spacewanderlzx@gmail.com>