### PR TITLE
feat: change the order of header files to support openresty-1.23.5.1

### DIFF
--- a/src/ngx_grpc_client.c
+++ b/src/ngx_grpc_client.c
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-#include <assert.h>
-#include <dlfcn.h>
-#include <stdbool.h>
+
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
@@ -24,6 +22,9 @@
 #include <ngx_http_lua_util.h>
 #include <ngx_stream_lua_util.h>
 
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdbool.h>
 
 #ifndef NGX_GRPC_CLI_ENGINE_PATH
 #define NGX_GRPC_CLI_ENGINE_PATH ""


### PR DESCRIPTION
when I use `build-apisix-base.sh` to compile openresty-1.23.5.1. I found an error like this: https://trac.nginx.org/nginx/ticket/2312#comment:4.
And I found a solution in https://nginx.org/en/docs/dev/development_guide.html#include_files. So I wan to change the order of header files.